### PR TITLE
add pip config tool for mirror setting

### DIFF
--- a/tools/config_pip.sh
+++ b/tools/config_pip.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+mkdir -p ~/.pip
+cd ~/.pip
+touch pip.conf
+
+# Set pack-age index for users in China
+echo "[global]" > pip.conf
+echo "index-url = https://pypi.tuna.tsinghua.edu.cn/simple" >> pip.conf
+
+# copy to ROOT for sudoers
+sudo mkdir -p /root/.pip
+sudo cp ~/.pip/pip.conf /root/.pip/


### PR DESCRIPTION
pip install is too slow when download whl files from China network, and always timeout for the network issue
Add a tool to set pip.conf for users in China, to speed up the pip installation time.